### PR TITLE
Fix `protect_methods` setting being incorrectly overridden

### DIFF
--- a/src/Kodeine/Acl/Middleware/HasPermission.php
+++ b/src/Kodeine/Acl/Middleware/HasPermission.php
@@ -114,8 +114,8 @@ class HasPermission
         // UserController@index but only
         // UserController we use crud restful.
         $methods = is_array($methods) ? $methods :
-            in_array($caller, $resources) ?
-                $this->crud['resource'] : $this->crud['restful'];
+            (in_array($caller, $resources) ?
+                $this->crud['resource'] : $this->crud['restful']);
 
         // determine crud method we're trying to protect
         $crud = array_where($methods, function ($k, $v) use ($called) {


### PR DESCRIPTION
My `protect_methods` option was being ignored by this middleware.  It seems this ternary statement was consistently, incorrectly, replacing `$methods` with `$this->crud['resource']`.

This happened on PHP 5.6 on Windows 8.1 64-bit.  I haven't tested this issue on any other environments or PHP versions.

It seems PHP was interpreting the ternary statement as:

```
(is_array($methods) ? $methods : in_array($caller, $resources)) ?
                $this->crud['resource'] : $this->crud['restful'];
```

I.e. the only possible outcomes would be `$this->crud['resource']` or `$this->crud['restful']`.