### PR TITLE
Update Blade Directive for 'permission'

### DIFF
--- a/src/Kodeine/Acl/AclServiceProvider.php
+++ b/src/Kodeine/Acl/AclServiceProvider.php
@@ -71,11 +71,11 @@ class AclServiceProvider extends ServiceProvider
         });
 
         // permission
-        Blade::directive('permission', function($expression) {
+        Blade::directive('access', function($expression) {
             return "<?php if (Auth::check() && Auth::user()->can{$expression}): ?>";
         });
 
-        Blade::directive('endpermission', function() {
+        Blade::directive('endaccess', function() {
             return "<?php endif; ?>";
         });
     }


### PR DESCRIPTION
In newest Laravel 5.1 build you can not use  ````@permission````. Renaming this Blade Directive to ````access```` fixes this issue.