### PR TITLE
Update Blade Directives for L5.1

### DIFF
--- a/src/Kodeine/Acl/AclServiceProvider.php
+++ b/src/Kodeine/Acl/AclServiceProvider.php
@@ -61,21 +61,17 @@ class AclServiceProvider extends ServiceProvider
      */
     protected function registerBladeExtensions()
     {
-        // role
-        Blade::directive('role', function($expression) {
+        $blade = $this->app['view']->getEngineResolver()->resolve('blade')->getCompiler();
+        $blade->directive('role', function ($expression) {
             return "<?php if (Auth::check() && Auth::user()->is{$expression}): ?>";
         });
-
-        Blade::directive('endrole', function() {
+        $blade->directive('endrole', function () {
             return "<?php endif; ?>";
         });
-
-        // permission
-        Blade::directive('access', function($expression) {
+        $blade->directive('permission', function ($expression) {
             return "<?php if (Auth::check() && Auth::user()->can{$expression}): ?>";
         });
-
-        Blade::directive('endaccess', function() {
+        $blade->directive('endpermission', function () {
             return "<?php endif; ?>";
         });
     }

--- a/src/Kodeine/Acl/AclServiceProvider.php
+++ b/src/Kodeine/Acl/AclServiceProvider.php
@@ -71,11 +71,11 @@ class AclServiceProvider extends ServiceProvider
         });
 
         // permission
-        Blade::directive('permission', function($expression) {
+        Blade::directive('access', function($expression) {
             return "<?php if (Auth::check() && Auth::user()->can{$expression}): ?>";
         });
 
-        Blade::directive('endpermission', function() {
+        Blade::directive('endaccess', function() {
             return "<?php endif; ?>";
         });
     }


### PR DESCRIPTION
As of the newest L5.1, ````@permission```` is already registered in the framework. PR solves this by overriding the other directives.