### PR TITLE
Fix constraint integrity errors, use 64 bit user IDs

### DIFF
--- a/src/migrations/2015_02_07_172633_create_role_user_table.php
+++ b/src/migrations/2015_02_07_172633_create_role_user_table.php
@@ -15,10 +15,8 @@ class CreateRoleUserTable extends Migration
     {
         Schema::create('role_user', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('role_id')->unsigned()->index();
-            $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
-            $table->integer('user_id')->unsigned()->index();
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->integer('role_id')->unsigned()->index()->foreign()->references("id")->on("roles")->onDelete("cascade");
+            $table->integer('user_id')->unsigned()->index()->foreign()->references("id")->on("users")->onDelete("cascade");
             $table->timestamps();
         });
     }

--- a/src/migrations/2015_02_17_152439_create_permission_user_table.php
+++ b/src/migrations/2015_02_17_152439_create_permission_user_table.php
@@ -14,10 +14,8 @@ class CreatePermissionUserTable extends Migration {
 	{
 		Schema::create('permission_user', function (Blueprint $table) {
 			$table->increments('id');
-			$table->integer('permission_id')->unsigned()->index();
-			$table->foreign('permission_id')->references('id')->on('permissions')->onDelete('cascade');
-			$table->integer('user_id')->unsigned()->index();
-			$table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+			$table->integer('permission_id')->unsigned()->index()->references('id')->on('permissions')->onDelete('cascade');
+			$table->integer('user_id')->unsigned()->index()->references('id')->on('users')->onDelete('cascade');
 			$table->timestamps();
 		});
 	}

--- a/src/migrations/2015_11_30_232041_bigint_user_keys.php
+++ b/src/migrations/2015_11_30_232041_bigint_user_keys.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class BigintUserKeys extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('role_user', function (Blueprint $table) {
+            $table->bigInteger("user_id")->unsigned()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('role_user', function (Blueprint $table) {
+            $table->integer("user_id")->unsigned()->change();
+        });
+    }
+}


### PR DESCRIPTION
Hi @kodeine . Thanks for the lib. I couldn't migrate upon publishing the upstream migrations. Probably because of the context and atomicity loss when you re-declare a column. Or at least that's my theory. Anyway. This PR changes the separated index and constraint creation into one chain. It also changes user_id to a BIGINT/int64. Which is probably the best choice of column type for an upstream thing like this, or at least a more widely compatible default than the default 32 bit ints.