### PR TITLE
Cast the users roles as an array instead of object.

### DIFF
--- a/src/Kodeine/Acl/Traits/HasRole.php
+++ b/src/Kodeine/Acl/Traits/HasRole.php
@@ -63,6 +63,7 @@ trait HasRole
         $operator = is_null($operator) ? $this->parseOperator($slug) : $operator;
 
         $roles = $this->getRoles();
+        $roles = (array) $roles;
         $slug = $this->hasDelimiterToArray($slug);
 
         // array of slugs


### PR DESCRIPTION
Casting the users role as an array instead of an object - it's causing an error on the old Line 64 (Now line 65)