### PR TITLE
Don't override user permission set to false by role

### DIFF
--- a/src/Kodeine/Acl/Traits/HasPermission.php
+++ b/src/Kodeine/Acl/Traits/HasPermission.php
@@ -44,7 +44,9 @@ trait HasPermission
             foreach ($role->getPermissions() as $slug => $array) {
                 if ( array_key_exists($slug, $permissions) ) {
                     foreach ($array as $clearance => $value) {
-                        ! $value ?: $permissions[$slug][$clearance] = true;
+                        if( !array_key_exists( $clearance, $permissions[$slug] ) ) {
+                            ! $value ?: $permissions[$slug][$clearance] = true;
+                        }
                     }
                 } else {
                     $permissions = array_merge($permissions, [$slug => $array]);


### PR DESCRIPTION
If a user has a permission set to false, it will currently be overridden by the role permission. This PR attempts to fix that.