### PR TITLE
Fix 5.2 config for Permission model

### DIFF
--- a/src/Kodeine/Acl/Models/Eloquent/Permission.php
+++ b/src/Kodeine/Acl/Models/Eloquent/Permission.php
@@ -37,7 +37,7 @@ class Permission extends Model
      */
     public function users()
     {
-        return $this->belongsToMany(config('auth.model'))->withTimestamps();
+        return $this->belongsToMany(config('auth.providers.users.model', config('auth.model')))->withTimestamps();
     }
 
     /**


### PR DESCRIPTION
This adds to #118 - the original PR only handled `Role` and neglected `Permission`.