### PR TITLE
Roles permissions are not mixed correctly

### DIFF
--- a/src/Kodeine/Acl/Traits/HasPermission.php
+++ b/src/Kodeine/Acl/Traits/HasPermission.php
@@ -48,11 +48,9 @@ trait HasPermission
         // true values.
         foreach ($this->roles as $role) {
             foreach ($role->getPermissions() as $slug => $array) {
-                if ( array_key_exists($slug, $permissions) ) {
+                if (array_key_exists($slug, $permissions)) {
                     foreach ($array as $clearance => $value) {
-                        if( !array_key_exists( $clearance, $permissions[$slug] ) ) {
-                            ! $value ?: $permissions[$slug][$clearance] = true;
-                        }
+                        ! $value ?: $permissions[$slug][$clearance] = true;
                     }
                 } else {
                     $permissions = array_merge($permissions, [$slug => $array]);
@@ -102,7 +100,7 @@ trait HasPermission
 
             $permissionId = $this->parsePermissionId($permission);
 
-            if ( ! $this->permissions->keyBy('id')->has($permissionId) ) {
+            if (! $this->permissions->keyBy('id')->has($permissionId)) {
                 $this->permissions()->attach($permissionId);
 
                 return $permission;
@@ -173,13 +171,12 @@ trait HasPermission
      */
     protected function parsePermissionId($permission)
     {
-        if ( is_string($permission) || is_numeric($permission) ) {
-
+        if (is_string($permission) || is_numeric($permission)) {
             $model = config('acl.permission', 'Kodeine\Acl\Models\Eloquent\Permission');
             $key = is_numeric($permission) ? 'id' : 'name';
             $alias = (new $model)->where($key, $permission)->first();
 
-            if ( ! is_object($alias) || ! $alias->exists ) {
+            if (! is_object($alias) || ! $alias->exists) {
                 throw new \InvalidArgumentException('Specified permission ' . $key . ' does not exists.');
             }
 
@@ -187,7 +184,7 @@ trait HasPermission
         }
 
         $model = '\Illuminate\Database\Eloquent\Model';
-        if ( is_object($permission) && $permission instanceof $model ) {
+        if (is_object($permission) && $permission instanceof $model) {
             $permission = $permission->getKey();
         }
 


### PR DESCRIPTION
// permissions based on role.
// more permissive permission wins
// if user has multiple roles we keep
// true values.

This does not happen because of the following condition:

if( !array_key_exists( $clearance, $permissions[$slug] ) ) {
    ! $value ?: $permissions[$slug][$clearance] = true;
}