### PR TITLE
- Fixed issue where getRoles and getPermissions methods returned empty lists

### DIFF
--- a/src/Kodeine/Acl/Traits/HasPermission.php
+++ b/src/Kodeine/Acl/Traits/HasPermission.php
@@ -46,7 +46,7 @@ trait HasPermission
         // more permissive permission wins
         // if user has multiple roles we keep
         // true values.
-        foreach ($this->roles as $role) {
+        foreach ($this->roles()->get() as $role) {
             foreach ($role->getPermissions() as $slug => $array) {
                 if ( array_key_exists($slug, $permissions) ) {
                     foreach ($array as $clearance => $value) {

--- a/src/Kodeine/Acl/Traits/HasPermissionInheritance.php
+++ b/src/Kodeine/Acl/Traits/HasPermissionInheritance.php
@@ -15,7 +15,7 @@ trait HasPermissionInheritance
     public function getPermissionsInherited()
     {
         $rights = [];
-        $permissions = $this->permissions;
+        $permissions = $this->permissions()->get();
 
         // ntfs permissions
         // determine if ntfs is enabled

--- a/src/Kodeine/Acl/Traits/HasRole.php
+++ b/src/Kodeine/Acl/Traits/HasRole.php
@@ -35,7 +35,7 @@ trait HasRoleImplementation
             'acl.getRolesById_'.$this->id,
             config('acl.cacheMinutes'),
             function () {
-                return $this->roles;
+                return $this->roles()->get();
             }
         );
 


### PR DESCRIPTION
This fixes issue on Laravel 5.3 where existing model instances wouldn't work:


```php
$user_admin = \App\User::first();
$user_admin->assignRole(ROLE_ADMIN);

// $user_admin->getRoles is empty!
$this->assertEquals($user_admin->getRoles(), [
    1 => ROLE_ADMIN
]);
// $user_admin->getPermissions is empty!
$this->assertEquals($user_admin->getPermissions(), $admin_role->getPermissions());
```

However, new created user works:

```php
$user_admin = new User();
$user_admin->firstname = 'Role';
$user_admin->lastname = 'test';
$user_admin->newsletter = 0;
$user_admin->email = 'role@test.com';
$user_admin->password = 'RoleTest';
$user_admin->save();

$user_admin->assignRole(ROLE_ADMIN);

// Test passes.
$this->assertEquals($user_admin->getRoles(), [
    1 => ROLE_ADMIN
]);
// Test passes.
$this->assertEquals($user_admin->getPermissions(), $admin_role->getPermissions());
```