### PR TITLE
Increase slug size

### DIFF
--- a/src/Kodeine/Acl/Models/Eloquent/Permission.php
+++ b/src/Kodeine/Acl/Models/Eloquent/Permission.php
@@ -1,6 +1,7 @@
 <?php namespace Kodeine\Acl\Models\Eloquent;
 
 use Illuminate\Database\Eloquent\Model;
+use Exception;
 
 class Permission extends Model
 {
@@ -51,6 +52,8 @@ class Permission extends Model
 
     /**
      * @param $value
+     *
+     * @throws Exception
      */
     public function setSlugAttribute($value)
     {
@@ -74,7 +77,12 @@ class Permission extends Model
         $value = array_filter($value, 'is_bool');
 
         // store as json.
-        $this->attributes['slug'] = json_encode($value);
+        $json = json_encode($value);
+        if (strlen($json) > 1024) {
+            throw new Exception('Slug max length (1024) is exceeded. Consider reducing amount ' .
+                            'of slug items and/or move them into different permission.');
+        }
+        $this->attributes['slug'] = $json;
     }
 
 }

--- a/src/migrations/2015_02_07_172649_create_permissions_table.php
+++ b/src/migrations/2015_02_07_172649_create_permissions_table.php
@@ -18,7 +18,7 @@ class CreatePermissionsTable extends Migration
             $table->integer('inherit_id')->unsigned()->nullable()->index();
             $table->foreign('inherit_id')->references('id')->on('permissions');
             $table->string('name')->index();
-            $table->string('slug')->index();
+            $table->string('slug', 1024)->index();
             $table->text('description')->nullable();
             $table->timestamps();
         });


### PR DESCRIPTION
This commit increases initial value for `slug` field in `permissions` table and adds an exception when JSON representation of `slug` fields exceeds 1024 characters.
The reason for that is permission rules are stored as a JSON string and when user assign too many rules to permission it would give him a DB error without any description what happened.