### PR TITLE
Fixed multiple permissions on same role, and with shared root permissions

### DIFF
--- a/src/Kodeine/Acl/Traits/HasPermissionInheritance.php
+++ b/src/Kodeine/Acl/Traits/HasPermissionInheritance.php
@@ -53,7 +53,22 @@ trait HasPermissionInheritance
             $merge = $this->collectionAsArray($merge);
 
             // replace and merge permissions
-            $rights = array_replace_recursive($rights, $inherited, $merge);
+            if ($inherited) {
+                foreach ($merge as $name => $perms) {
+                    foreach ($perms as $pname => $pvalue) {
+                        $inherited[$name] = isset($inherited[$name]) ? $inherited[$name] : [];
+                        $inherited[$name][$pname] = empty($inherited[$name][$pname]) ? $merge[$name][$pname] : $inherited[$name][$pname];
+                    }
+                }
+            } else {
+                $inherited = $merge;
+            }
+            foreach ($inherited as $name => $perms) {
+                foreach ($perms as $pname => $pvalue) {
+                    $rights[$name] = isset($rights[$name]) ? $rights[$name] : [];
+                    $rights[$name][$pname] = empty($rights[$name][$pname]) ? $inherited[$name][$pname] : $rights[$name][$pname];
+                }
+            }
 
             // make sure we don't unset if
             // inherited & slave permission


### PR DESCRIPTION
I had following issue:
Permission A which is a parent permission.
Two children permissions B and C that inherit from A.

I have 2 roles, one that has permission B and one that has permission C.
But I also have a superadmin role that has automatically all the permissions, so it has permission A, B and C. I expected it would have all the permissions of B and C, but in fact it only had the permissions from either B or C, depending which one was inserted last in the database.

I changed the code, so if for example B has permission ['edit' => true] and C has permission ['edit' => false], the superadmin will have permission ['edit' => true], no matter which one of B and C was inserted last in the database.

assumption of the library:
slugs are a list of key-values where the value is always a boolean.