### PR TITLE
Fixes a phpunit fatal error when xdebug is enabled

### DIFF
--- a/src/Kodeine/Acl/Traits/HasRole.php
+++ b/src/Kodeine/Acl/Traits/HasRole.php
@@ -281,7 +281,7 @@ trait HasRoleImplementation
 }
 
 $laravel = app();
-if (version_compare($laravel::VERSION, '5.3', '<')) {
+if ($laravel::VERSION !== null && version_compare($laravel::VERSION, '5.3', '<')) {
     trait HasRole
     {
         use HasRoleImplementation {


### PR DESCRIPTION
Checks if $laravel::VERSION exists before the comparison, fixes #174 