### PR TITLE
Check that $laravel is an instance of the correct class

### DIFF
--- a/src/Kodeine/Acl/Traits/HasRole.php
+++ b/src/Kodeine/Acl/Traits/HasRole.php
@@ -281,7 +281,7 @@ trait HasRoleImplementation
 }
 
 $laravel = app();
-if (version_compare($laravel::VERSION, '5.3', '<')) {
+if ($laravel instanceof \Illuminate\Foundation\Application && version_compare($laravel::VERSION, '5.3', '<')) {
     trait HasRole
     {
         use HasRoleImplementation {


### PR DESCRIPTION
This fixes a problem that happens with PHP 7.1 when xdebug is enabled:
phpunit evaluates $laravel as an instance of
Illuminate\Container\Container instead of
\Illuminate\Foundation\Application so it doesn’t find the constant
VERSION nor the method version(), and throws a fatal error.

Fixes #174 