### PR TITLE
Updating for 5.4 and adding customizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 Thumbs.db
 .idea
 Acl_*
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ matrix:
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source --dev
+
+script:
+  - vendor/bin/phpunit --debug tests/

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Laravel ACL adds role based permissions to built in Auth System of Laravel 5. AC
 ```php
 'providers' => [
 
-'Illuminate\Foundation\Providers\ArtisanServiceProvider',
-'Illuminate\Auth\AuthServiceProvider',
+Illuminate\Foundation\Providers\ArtisanServiceProvider::class,
+Illuminate\Auth\AuthServiceProvider::class,
 ...
-'Kodeine\Acl\AclServiceProvider',
+Kodeine\Acl\AclServiceProvider::class,
 
 ],
 ```
@@ -62,7 +62,7 @@ $ php artisan vendor:publish --provider="Kodeine\Acl\AclServiceProvider"
 protected $routeMiddleware = [
 
 ....
-'acl' => 'Kodeine\Acl\Middleware\HasPermission',
+'acl' => Kodeine\Acl\Middleware\HasPermission::class,
 
 ];
 ```
@@ -74,7 +74,7 @@ use Kodeine\Acl\Traits\HasRole;
 
 class User extends Model implements AuthenticatableContract, CanResetPasswordContract
 {
-use Authenticatable, CanResetPassword, HasRole;
+    use Authenticatable, CanResetPassword, HasRole;
 }
 ```
 
@@ -92,6 +92,14 @@ Here's the TODO list for the next release (**2.0**).
 * [ ] Adding tests.
 
 # <a name="change-logs"></a>Change Logs
+
+** March 13, 2017
+* [x] Updated for Laravel 5.4.
+* [x] Migrations run locally instead of being published.
+* [x] Config option to specify database table prefix added.
+* [x] Config option to detail non-standard users table name added.
+* [x] `can()` renamed to `hasPermission()`.
+* [x] `is()` renamed to `isRole()`.
 
 **June 14, 2015 (latest)**
 * [x] Added backward compatibility to l5.0 for lists() method.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=5.6.4",
         "illuminate/support": "~5.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,11 @@
         "php": ">=5.6.4",
         "illuminate/support": "~5.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4.0",
+        "orchestra/testbench": "~3.0",
+        "doctrine/dbal": "^2.5"
+    },
     "autoload": {
         "psr-4": {
             "Kodeine\\Acl\\": "src/Kodeine/Acl"

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,10 @@
         "psr-4": {
             "Kodeine\\Acl\\": "src/Kodeine/Acl"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Kodeine\\Acl\\Tests\\": "tests/"
+        }
     }
 }

--- a/src/Kodeine/Acl/AclServiceProvider.php
+++ b/src/Kodeine/Acl/AclServiceProvider.php
@@ -1,4 +1,6 @@
-<?php namespace Kodeine\Acl;
+<?php
+
+namespace Kodeine\Acl;
 
 use Blade;
 use Illuminate\Support\ServiceProvider;
@@ -20,7 +22,7 @@ class AclServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishConfig();
-        $this->publishMigration();
+        $this->loadMigrations();
 
         $laravel = app();
         if ( starts_with($laravel::VERSION, '5.0') ) {
@@ -55,11 +57,9 @@ class AclServiceProvider extends ServiceProvider
     /**
      * Publish the migration to the application migration folder
      */
-    public function publishMigration()
+    public function loadMigrations()
     {
-        $this->publishes([
-            __DIR__ . '/../../migrations/' => base_path('/database/migrations'),
-        ], 'migrations');
+        $this->loadMigrationsFrom(__DIR__ . '/../../migrations');
     }
 
     /**

--- a/src/Kodeine/Acl/Helper/Helper.php
+++ b/src/Kodeine/Acl/Helper/Helper.php
@@ -1,4 +1,6 @@
-<?php namespace Kodeine\Acl\Helper;
+<?php
+
+namespace Kodeine\Acl\Helper;
 
 use Illuminate\Support\Collection;
 
@@ -122,5 +124,4 @@ trait Helper
         // single item
         return $closure($item);
     }
-
 }

--- a/src/Kodeine/Acl/Middleware/HasPermission.php
+++ b/src/Kodeine/Acl/Middleware/HasPermission.php
@@ -1,4 +1,6 @@
-<?php namespace Kodeine\Acl\Middleware;
+<?php
+
+namespace Kodeine\Acl\Middleware;
 
 use Closure;
 
@@ -72,7 +74,7 @@ class HasPermission
         $request = $this->request;
         $role = $this->getAction('is');
 
-        return ! $this->forbiddenRoute() && $request->user()->is($role);
+        return ! $this->forbiddenRoute() && $request->user()->isRole($role);
     }
 
     /**
@@ -85,7 +87,7 @@ class HasPermission
         $request = $this->request;
         $do = $this->getAction('can');
 
-        return ! $this->forbiddenRoute() && $request->user()->can($do);
+        return ! $this->forbiddenRoute() && $request->user()->hasPermission($do);
     }
 
     /**
@@ -131,7 +133,7 @@ class HasPermission
             return $e . '.' . $this->parseAlias();
         }, array_keys($crud)));
 
-        return ! $this->forbiddenRoute() && $request->user()->can($permission);
+        return ! $this->forbiddenRoute() && $request->user()->hasPermission($permission);
     }
 
     /**
@@ -223,5 +225,4 @@ class HasPermission
             $this->crud['resource'] = $resource;
         }
     }
-
 }

--- a/src/Kodeine/Acl/Models/Eloquent/Permission.php
+++ b/src/Kodeine/Acl/Models/Eloquent/Permission.php
@@ -1,4 +1,6 @@
-<?php namespace Kodeine\Acl\Models\Eloquent;
+<?php
+
+namespace Kodeine\Acl\Models\Eloquent;
 
 use Illuminate\Database\Eloquent\Model;
 
@@ -16,7 +18,14 @@ class Permission extends Model
      *
      * @var string
      */
-    protected $table = 'permissions';
+    protected $table;
+
+    public function __construct(array $attributes = [])
+    {
+        $this->table = config('acl.db_prefix') . 'permissions';
+
+        parent::__construct($attributes);
+    }
 
     /**
      * Permissions can belong to many roles.
@@ -37,7 +46,7 @@ class Permission extends Model
      */
     public function users()
     {
-        return $this->belongsToMany(config('auth.model'))->withTimestamps();
+        return $this->belongsToMany(config('auth.providers.users.model'))->withTimestamps();
     }
 
     /**
@@ -76,5 +85,4 @@ class Permission extends Model
         // store as json.
         $this->attributes['slug'] = json_encode($value);
     }
-
 }

--- a/src/Kodeine/Acl/Models/Eloquent/Role.php
+++ b/src/Kodeine/Acl/Models/Eloquent/Role.php
@@ -1,4 +1,6 @@
-<?php namespace Kodeine\Acl\Models\Eloquent;
+<?php
+
+namespace Kodeine\Acl\Models\Eloquent;
 
 use Illuminate\Database\Eloquent\Model;
 use Kodeine\Acl\Traits\HasPermission;
@@ -19,7 +21,14 @@ class Role extends Model
      *
      * @var string
      */
-    protected $table = 'roles';
+    protected $table;
+
+    public function __construct(array $attributes = [])
+    {
+        $this->table = config('acl.db_prefix') . 'roles';
+
+        parent::__construct($attributes);
+    }
 
     /**
      * Roles can belong to many users.
@@ -28,7 +37,7 @@ class Role extends Model
      */
     public function users()
     {
-        return $this->belongsToMany(config('auth.model'))->withTimestamps();
+        return $this->belongsToMany(config('auth.provider.users.model'))->withTimestamps();
     }
 
     /**
@@ -49,7 +58,7 @@ class Role extends Model
      * @param array  $mergePermissions
      * @return bool
      */
-    public function can($permission, $operator = null, $mergePermissions = [])
+    public function hasPermission($permission, $operator = null, $mergePermissions = [])
     {
         $operator = is_null($operator) ? $this->parseOperator($permission) : $operator;
 
@@ -108,5 +117,4 @@ class Role extends Model
 
         return false;
     }
-
 }

--- a/src/Kodeine/Acl/Traits/HasPermission.php
+++ b/src/Kodeine/Acl/Traits/HasPermission.php
@@ -1,4 +1,6 @@
-<?php namespace Kodeine\Acl\Traits;
+<?php
+
+namespace Kodeine\Acl\Traits;
 
 use Kodeine\Acl\Helper\Helper;
 
@@ -20,9 +22,13 @@ trait HasPermission
      */
     public function permissions()
     {
-        $model = config('acl.permission', 'Kodeine\Acl\Models\Eloquent\Permission');
+        $model  = config('acl.permission', 'Kodeine\Acl\Models\Eloquent\Permission');
+        $prefix = config('acl.db_prefix');
 
-        return $this->belongsToMany($model)->withTimestamps();
+        $class = get_called_class();
+        $table = $class === config('auth.providers.users.model') ? 'permission_user' : 'permission_role';
+
+        return $this->belongsToMany($model, $prefix . $table)->withTimestamps();
     }
 
     /**
@@ -42,7 +48,7 @@ trait HasPermission
         // true values.
         foreach ($this->roles as $role) {
             foreach ($role->getPermissions() as $slug => $array) {
-                if ( array_key_exists($slug, $permissions) ) {
+                if (array_key_exists($slug, $permissions)) {
                     foreach ($array as $clearance => $value) {
                         ! $value ?: $permissions[$slug][$clearance] = true;
                     }
@@ -60,26 +66,28 @@ trait HasPermission
      *
      * @param  string $permission
      * @param  string $operator
+     *
      * @return bool
      */
-    public function can($permission, $operator = null)
+    public function hasPermission($permission, $operator = null)
     {
         // user permissions including
         // all of user role permissions
         $merge = $this->getPermissions();
 
-        // lets call our base can() method
+        // lets call our base hasPermission() method
         // from role class. $merge already
         // has user & role permissions
         $model = config('acl.role', 'Kodeine\Acl\Models\Eloquent\Role');
 
-        return (new $model)->can($permission, $operator, $merge);
+        return (new $model)->hasPermission($permission, $operator, $merge);
     }
 
     /**
      * Assigns the given permission to the user.
      *
      * @param  collection|object|array|string|int $permission
+     *
      * @return bool
      */
     public function assignPermission($permission)
@@ -88,7 +96,7 @@ trait HasPermission
 
             $permissionId = $this->parsePermissionId($permission);
 
-            if ( ! $this->permissions->keyBy('id')->has($permissionId) ) {
+            if (! $this->permissions->keyBy('id')->has($permissionId)) {
                 $this->permissions()->attach($permissionId);
 
                 return $permission;
@@ -102,6 +110,7 @@ trait HasPermission
      * Revokes the given permission from the user.
      *
      * @param  collection|object|array|string|int $permission
+     *
      * @return bool
      */
     public function revokePermission($permission)
@@ -118,6 +127,7 @@ trait HasPermission
      * Syncs the given permission(s) with the user.
      *
      * @param  collection|object|array|string|int $permissions
+     *
      * @return bool
      */
     public function syncPermissions($permissions)
@@ -150,22 +160,22 @@ trait HasPermission
     |
     */
 
-
     /**
      * Parses permission id from object or array.
      *
      * @param object|array|int $permission
+     *
      * @return mixed
      */
     protected function parsePermissionId($permission)
     {
-        if ( is_string($permission) || is_numeric($permission) ) {
+        if (is_string($permission) || is_numeric($permission)) {
 
             $model = config('acl.permission', 'Kodeine\Acl\Models\Eloquent\Permission');
-            $key = is_numeric($permission) ? 'id' : 'name';
+            $key   = is_numeric($permission) ? 'id' : 'name';
             $alias = (new $model)->where($key, $permission)->first();
 
-            if ( ! is_object($alias) || ! $alias->exists ) {
+            if (! is_object($alias) || ! $alias->exists) {
                 throw new \InvalidArgumentException('Specified permission ' . $key . ' does not exists.');
             }
 
@@ -173,10 +183,10 @@ trait HasPermission
         }
 
         $model = '\Illuminate\Database\Eloquent\Model';
-        if ( is_object($permission) && $permission instanceof $model ) {
+        if (is_object($permission) && $permission instanceof $model) {
             $permission = $permission->getKey();
         }
 
-        return (int) $permission;
+        return (int)$permission;
     }
 }

--- a/src/Kodeine/Acl/Traits/HasPermissionInheritance.php
+++ b/src/Kodeine/Acl/Traits/HasPermissionInheritance.php
@@ -1,5 +1,6 @@
-<?php namespace Kodeine\Acl\Traits;
+<?php
 
+namespace Kodeine\Acl\Traits;
 
 trait HasPermissionInheritance
 {
@@ -191,5 +192,4 @@ trait HasPermissionInheritance
 
         return (int) $permission;
     }*/
-
 }

--- a/src/Kodeine/Acl/Traits/HasUserPermission.php
+++ b/src/Kodeine/Acl/Traits/HasUserPermission.php
@@ -1,4 +1,6 @@
-<?php namespace Kodeine\Acl\Traits;
+<?php
+
+namespace Kodeine\Acl\Traits;
 
 use Illuminate\Support\Collection;
 
@@ -148,5 +150,4 @@ trait HasUserPermission
 
         return $collection->get($alias);
     }
-
 }

--- a/src/config/acl.php
+++ b/src/config/acl.php
@@ -1,23 +1,49 @@
 <?php
 
 return [
+    /*
+    |--------------------------------------------------------------------------
+    | Model Definitions
+    |--------------------------------------------------------------------------
+    |
+    | If you want to use your own model and extend it to package's model. You
+    | can define your model here.
+    */
 
-    /**
-     * Model definitions.
-     * If you want to use your own model and extend it
-     * to package's model. You can define your model here.
-     */
+    'role'       => Kodeine\Acl\Models\Eloquent\Role::class,
+    'permission' => Kodeine\Acl\Models\Eloquent\Permission::class,
 
-    'role'       => 'Kodeine\Acl\Models\Eloquent\Role',
-    'permission' => 'Kodeine\Acl\Models\Eloquent\Permission',
+    /*
+    |--------------------------------------------------------------------------
+    | Most Permissive Wins Right
+    |--------------------------------------------------------------------------
+    |
+    | If you have multiple permission aliases assigned, each alias has a common
+    | permission, view.house => false, but one alias has it set to true. If this
+    | right is enabled, true value wins the race, ie the most permissive wins.
+    */
 
-    /**
-     * Most Permissive Wins right
-     * If you have multiple permission aliases assigned, each alias
-     * has a common permission, view.house => false, but one alias
-     * has it set to true. If this right is enabled, true value
-     * wins the race, ie the most permissive wins.
-     */
+    'most_permissive_wins' => false,
 
-    'most_permissive_wins'       => false,
+    /*
+    |--------------------------------------------------------------------------
+    | Database Table Prefix
+    |--------------------------------------------------------------------------
+    |
+    | If you want to add a prefix to the table names, define it here.  By default,
+    | no prefix is applied.
+    */
+
+    'db_prefix' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | User Table
+    |--------------------------------------------------------------------------
+    |
+    | Most of the time the users are stored in a table named users.  If this is
+    | not true for your app, define the user table name here.
+    */
+
+    'users_table' => 'users',
 ];

--- a/src/migrations/2015_02_07_172606_create_roles_table.php
+++ b/src/migrations/2015_02_07_172606_create_roles_table.php
@@ -5,6 +5,15 @@ use Illuminate\Database\Migrations\Migration;
 
 class CreateRolesTable extends Migration
 {
+    /**
+     * @var string
+     */
+    public $prefix;
+
+    public function __construct()
+    {
+        $this->prefix = config('acl.db_prefix');
+    }
 
     /**
      * Run the migrations.
@@ -13,7 +22,7 @@ class CreateRolesTable extends Migration
      */
     public function up()
     {
-        Schema::create('roles', function (Blueprint $table) {
+        Schema::create($this->prefix . 'roles', function (Blueprint $table) {
             $table->increments('id');
             $table->string('name')->unique();
             $table->string('slug')->unique();
@@ -29,7 +38,7 @@ class CreateRolesTable extends Migration
      */
     public function down()
     {
-        Schema::drop('roles');
+        Schema::drop($this->prefix . 'roles');
     }
 
 }

--- a/src/migrations/2015_02_07_172633_create_role_user_table.php
+++ b/src/migrations/2015_02_07_172633_create_role_user_table.php
@@ -5,6 +5,15 @@ use Illuminate\Database\Migrations\Migration;
 
 class CreateRoleUserTable extends Migration
 {
+    /**
+     * @var string
+     */
+    public $prefix;
+
+    public function __construct()
+    {
+        $this->prefix = config('acl.db_prefix');
+    }
 
     /**
      * Run the migrations.
@@ -13,13 +22,21 @@ class CreateRoleUserTable extends Migration
      */
     public function up()
     {
-        Schema::create('role_user', function (Blueprint $table) {
+        Schema::create($this->prefix . 'role_user', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('role_id')->unsigned()->index();
-            $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
             $table->integer('user_id')->unsigned()->index();
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->timestamps();
+
+            $table->foreign('role_id')
+                ->references('id')
+                ->on($this->prefix . 'roles')
+                ->onDelete('cascade');
+
+            $table->foreign('user_id')
+                ->references('id')
+                ->on(config('acl.users_table'))
+                ->onDelete('cascade');
         });
     }
 
@@ -30,7 +47,7 @@ class CreateRoleUserTable extends Migration
      */
     public function down()
     {
-        Schema::drop('role_user');
+        Schema::drop($this->prefix . 'role_user');
     }
 
 }

--- a/src/migrations/2015_02_07_172649_create_permissions_table.php
+++ b/src/migrations/2015_02_07_172649_create_permissions_table.php
@@ -5,6 +5,15 @@ use Illuminate\Database\Migrations\Migration;
 
 class CreatePermissionsTable extends Migration
 {
+    /**
+     * @var string
+     */
+    public $prefix;
+
+    public function __construct()
+    {
+        $this->prefix = config('acl.db_prefix');
+    }
 
     /**
      * Run the migrations.
@@ -13,14 +22,17 @@ class CreatePermissionsTable extends Migration
      */
     public function up()
     {
-        Schema::create('permissions', function (Blueprint $table) {
+        Schema::create($this->prefix . 'permissions', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('inherit_id')->unsigned()->nullable()->index();
-            $table->foreign('inherit_id')->references('id')->on('permissions');
             $table->string('name')->index();
             $table->string('slug')->index();
             $table->text('description')->nullable();
             $table->timestamps();
+
+            $table->foreign('inherit_id')
+                ->references('id')
+                ->on($this->prefix . 'permissions');
         });
     }
 
@@ -31,7 +43,7 @@ class CreatePermissionsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('permissions');
+        Schema::drop($this->prefix . 'permissions');
     }
 
 }

--- a/src/migrations/2015_02_07_172657_create_permission_role_table.php
+++ b/src/migrations/2015_02_07_172657_create_permission_role_table.php
@@ -5,6 +5,15 @@ use Illuminate\Database\Migrations\Migration;
 
 class CreatePermissionRoleTable extends Migration
 {
+    /**
+     * @var string
+     */
+    public $prefix;
+
+    public function __construct()
+    {
+        $this->prefix = config('acl.db_prefix');
+    }
 
     /**
      * Run the migrations.
@@ -13,13 +22,21 @@ class CreatePermissionRoleTable extends Migration
      */
     public function up()
     {
-        Schema::create('permission_role', function (Blueprint $table) {
+        Schema::create($this->prefix . 'permission_role', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('permission_id')->unsigned()->index();
-            $table->foreign('permission_id')->references('id')->on('permissions')->onDelete('cascade');
             $table->integer('role_id')->unsigned()->index();
-            $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
             $table->timestamps();
+
+            $table->foreign('permission_id')
+                ->references('id')
+                ->on($this->prefix . 'permissions')
+                ->onDelete('cascade');
+
+            $table->foreign('role_id')
+                ->references('id')
+                ->on($this->prefix . 'roles')
+                ->onDelete('cascade');
         });
     }
 
@@ -30,7 +47,7 @@ class CreatePermissionRoleTable extends Migration
      */
     public function down()
     {
-        Schema::drop('permission_role');
+        Schema::drop($this->prefix . 'permission_role');
     }
 
 }

--- a/src/migrations/2015_02_17_152439_create_permission_user_table.php
+++ b/src/migrations/2015_02_17_152439_create_permission_user_table.php
@@ -3,23 +3,41 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreatePermissionUserTable extends Migration {
+class CreatePermissionUserTable extends Migration
+{
+    /**
+     * @var string
+     */
+    public $prefix;
 
-	/**
+    public function __construct()
+    {
+        $this->prefix = config('acl.db_prefix');
+    }
+
+    /**
 	 * Run the migrations.
 	 *
 	 * @return void
 	 */
 	public function up()
 	{
-		Schema::create('permission_user', function (Blueprint $table) {
+		Schema::create($this->prefix . 'permission_user', function (Blueprint $table) {
 			$table->increments('id');
 			$table->integer('permission_id')->unsigned()->index();
-			$table->foreign('permission_id')->references('id')->on('permissions')->onDelete('cascade');
-			$table->integer('user_id')->unsigned()->index();
-			$table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
-			$table->timestamps();
-		});
+            $table->integer('user_id')->unsigned()->index();
+            $table->timestamps();
+
+            $table->foreign('permission_id')
+                ->references('id')
+                ->on($this->prefix . 'permissions')
+                ->onDelete('cascade');
+
+            $table->foreign('user_id')
+                ->references('id')
+                ->on(config('acl.users_table'))
+                ->onDelete('cascade');
+        });
 	}
 
 	/**
@@ -29,7 +47,7 @@ class CreatePermissionUserTable extends Migration {
 	 */
 	public function down()
 	{
-		Schema::drop('permission_user');
+		Schema::drop($this->prefix . 'permission_user');
 	}
 
 }


### PR DESCRIPTION
* [x] Updated for Laravel 5.4.
* [x] Migrations run locally instead of being published.
* [x] Config option to specify database table prefix added.
* [x] Config option to detail non-standard users table name added.
* [x] `can()` renamed to `hasPermission()`.
* [x] `is()` renamed to `isRole()`.

Method renaming was due to conflicts with laravel 5.4 base code.