### PR TITLE
Add tags to the cache to easily purge ACL cache

### DIFF
--- a/src/Kodeine/Acl/Models/Eloquent/Role.php
+++ b/src/Kodeine/Acl/Models/Eloquent/Role.php
@@ -38,7 +38,7 @@ class Role extends Model
      */
     public function getPermissions()
     {
-        return \Cache::remember(
+        return \Cache::tags(config('acl.cacheTags', []))->remember(
             'acl.getPermissionsInheritedById_'.$this->id,
             config('acl.cacheMinutes'),
             function () {

--- a/src/Kodeine/Acl/Traits/HasPermission.php
+++ b/src/Kodeine/Acl/Traits/HasPermission.php
@@ -35,7 +35,7 @@ trait HasPermission
     {
         // user permissions overridden from role.
         $permissions = \Cache::tags(config('acl.cacheTags', []))->remember(
-            'acl.getPermissionsById_'.$this->id,
+            'acl.getPermissionsById_' . $this->id,
             config('acl.cacheMinutes'),
             function () {
                 return $this->getPermissionsInherited();
@@ -48,9 +48,9 @@ trait HasPermission
         // true values.
         foreach ($this->roles as $role) {
             foreach ($role->getPermissions() as $slug => $array) {
-                if ( array_key_exists($slug, $permissions) ) {
+                if (array_key_exists($slug, $permissions)) {
                     foreach ($array as $clearance => $value) {
-                        if( !array_key_exists( $clearance, $permissions[$slug] ) ) {
+                        if (array_key_exists($clearance, $permissions[$slug])) {
                             ! $value ?: $permissions[$slug][$clearance] = true;
                         }
                     }

--- a/src/Kodeine/Acl/Traits/HasPermission.php
+++ b/src/Kodeine/Acl/Traits/HasPermission.php
@@ -50,8 +50,12 @@ trait HasPermission
             foreach ($role->getPermissions() as $slug => $array) {
                 if (array_key_exists($slug, $permissions)) {
                     foreach ($array as $clearance => $value) {
-                        if (array_key_exists($clearance, $permissions[$slug])) {
+                        if (! array_key_exists($clearance, $permissions[$slug])) {
                             ! $value ?: $permissions[$slug][$clearance] = true;
+                        } else {
+                            if ($permissions[$slug][$clearance] != $value) {
+                                $permissions[$slug][$clearance] = $value;
+                            }
                         }
                     }
                 } else {

--- a/src/Kodeine/Acl/Traits/HasPermission.php
+++ b/src/Kodeine/Acl/Traits/HasPermission.php
@@ -34,7 +34,7 @@ trait HasPermission
     public function getPermissions()
     {
         // user permissions overridden from role.
-        $permissions = \Cache::remember(
+        $permissions = \Cache::tags(config('acl.cacheTags', []))->remember(
             'acl.getPermissionsById_'.$this->id,
             config('acl.cacheMinutes'),
             function () {
@@ -74,7 +74,7 @@ trait HasPermission
     {
         // user permissions including
         // all of user role permissions
-        $merge =  \Cache::remember(
+        $merge =  \Cache::tags(config('acl.cacheTags', []))->remember(
             'acl.getMergeById_'.$this->id,
             config('acl.cacheMinutes'),
             function () {

--- a/src/Kodeine/Acl/Traits/HasRole.php
+++ b/src/Kodeine/Acl/Traits/HasRole.php
@@ -26,7 +26,7 @@ trait HasRoleImplementation
     {
         $model = config('acl.role', 'Kodeine\Acl\Models\Eloquent\Role');
 
-        return $this->belongsToMany($model)->withTimestamps();
+        return $this->belongsToMany($model)->withTimestamps()->orderBy('roles.created_at');
     }
 
     /**

--- a/src/Kodeine/Acl/Traits/HasRole.php
+++ b/src/Kodeine/Acl/Traits/HasRole.php
@@ -36,7 +36,7 @@ trait HasRoleImplementation
      */
     public function getRoles()
     {
-        $this_roles = \Cache::remember(
+        $this_roles = \Cache::tags(config('acl.cacheTags', []))->remember(
             'acl.getRolesById_'.$this->id,
             config('acl.cacheMinutes'),
             function () {

--- a/src/config/acl.php
+++ b/src/config/acl.php
@@ -27,4 +27,11 @@ return [
      */
 		
     'cacheMinutes' => 1,
+
+    /**
+     * Cache tags
+     *
+     * All cached entries are tagged to easily purge them on demand
+     */
+    'cacheTags' => ['acl']
 ];


### PR DESCRIPTION
In order to purge only ACL cached entries, use the tags() method on the Cache facade. This way it is possible to purge only the ACL entries.

This functionality can be helpful when editing ACLs using an interface.