### PR TITLE
Laravel 6.0 compatibility updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
 
 6. Run the migrations to generate your roles and permissions tables
 
+Please note that if you are upgrading to 6.0 from a previous version, the default column type for the id on the users table has changed. On certain databases foreign keys can only be defined with matching column types. As such, you will need to change the id column on your users table to bigInteger in to user this package. 
+
 ```
 php artisan migrate
 ```

--- a/src/Kodeine/Acl/AclServiceProvider.php
+++ b/src/Kodeine/Acl/AclServiceProvider.php
@@ -4,7 +4,6 @@ namespace Kodeine\Acl;
 
 use Blade;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Str;
 
 class AclServiceProvider extends ServiceProvider
 {
@@ -24,15 +23,7 @@ class AclServiceProvider extends ServiceProvider
     {
         $this->publishConfig();
         $this->loadMigrationsFrom(__DIR__ . '/../../migrations');
-
-        $laravel = app();
-        if ( substr($laravel::VERSION, 0, 2) === (string) "5.0" ) {
-            $this->registerBlade5_0();
-        } else if ( (substr($laravel::VERSION, 0, 2) === (string) "5.1") || (substr($laravel::VERSION, 0, 2) === (string) "5.2") ) {
-            $this->registerBlade5_1();
-        } else {
-            $this->registerBlade5_3();
-        }
+        $this->registerBladeDirectives();
     }
 
     /**
@@ -57,7 +48,7 @@ class AclServiceProvider extends ServiceProvider
         ], 'config');
     }
 
-    protected function registerBlade5_3()
+    public function registerBladeDirectives()
     {
         // role
         Blade::directive('role', function ($expression) {
@@ -70,62 +61,11 @@ class AclServiceProvider extends ServiceProvider
 
         // permission
         Blade::directive('permission', function ($expression) {
-            return "<?php if (Auth::check() && Auth::user()->can({$expression})): ?>";
+            return "<?php if (Auth::check() && Auth::user()->hasPermission({$expression})): ?>";
         });
 
         Blade::directive('endpermission', function () {
             return "<?php endif; ?>";
-        });
-    }
-
-     /**
-     * Register Blade Template Extensions for >= L5.1
-     */
-    protected function registerBlade5_1()
-    {
-        // role
-        Blade::directive('role', function ($expression) {
-            return "<?php if (Auth::check() && Auth::user()->is{$expression}): ?>";
-        });
-
-        Blade::directive('endrole', function () {
-            return "<?php endif; ?>";
-        });
-
-        // permission
-        Blade::directive('permission', function ($expression) {
-            return "<?php if (Auth::check() && Auth::user()->can{$expression}): ?>";
-        });
-
-        Blade::directive('endpermission', function () {
-            return "<?php endif; ?>";
-        });
-    }
-
-    /**
-     * Register Blade Template Extensions for <= L5.0
-     */
-    protected function registerBlade5_0()
-    {
-        $blade = $this->app['view']->getEngineResolver()->resolve('blade')->getCompiler();
-        $blade->extend(function ($view, $compiler) {
-            $pattern = $compiler->createMatcher('role');
-            return preg_replace($pattern, '<?php if (Auth::check() && Auth::user()->is$2): ?> ', $view);
-        });
-
-        $blade->extend(function ($view, $compiler) {
-            $pattern = $compiler->createPlainMatcher('endrole');
-            return preg_replace($pattern, '<?php endif; ?>', $view);
-        });
-
-        $blade->extend(function ($view, $compiler) {
-            $pattern = $compiler->createMatcher('permission');
-            return preg_replace($pattern, '<?php if (Auth::check() && Auth::user()->can$2): ?> ', $view);
-        });
-
-        $blade->extend(function ($view, $compiler) {
-            $pattern = $compiler->createPlainMatcher('endpermission');
-            return preg_replace($pattern, '<?php endif; ?>', $view);
         });
     }
 }

--- a/src/Kodeine/Acl/Helper/Helper.php
+++ b/src/Kodeine/Acl/Helper/Helper.php
@@ -8,28 +8,6 @@ trait Helper
 {
     /*
     |----------------------------------------------------------------------
-    | Collection methods compatible with L5.1.
-    |----------------------------------------------------------------------
-    |
-    */
-
-    /**
-     * Lists() method in l5.1 returns collection.
-     * This method fixes that issue for backward
-     * compatibility.
-     *
-     * @param $data
-     * @return mixed
-     */
-    protected function collectionAsArray($data)
-    {
-        return ($data instanceof Collection)
-            ? $data->toArray()
-            : $data;
-    }
-
-    /*
-    |----------------------------------------------------------------------
     | Slug Permission Related Protected Methods
     |----------------------------------------------------------------------
     |
@@ -104,9 +82,7 @@ trait Helper
 
         // item is a collection.
         if ($item instanceof Collection) {
-            $item = $this->collectionAsArray(
-                method_exists($item, 'pluck') ? $item->pluck('name') : $item->lists('name')
-            );
+            $item = $item->pluck('name')->all();
         }
 
         // multiple items

--- a/src/Kodeine/Acl/Middleware/HasPermission.php
+++ b/src/Kodeine/Acl/Middleware/HasPermission.php
@@ -155,13 +155,6 @@ class HasPermission
      */
     protected function forbiddenRoute()
     {
-        /*$action = $request->route()->getAction();
-        if ( isset($action['except']) ) {
-            dd($request->user()->roles->lists('slug'));
-            dd($request->user()->getPermissions());
-            //return $action['except'] == $request->user()->role->slug;
-        }*/
-
         return false;
     }
 

--- a/src/Kodeine/Acl/Models/Eloquent/User.php
+++ b/src/Kodeine/Acl/Models/Eloquent/User.php
@@ -1,28 +1,20 @@
-<?php namespace Kodeine\Acl\Models\Eloquent;
+<?php 
+namespace Kodeine\Acl\Models\Eloquent;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Auth\Authenticatable;
-
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\SoftDeletes;
-
-use Illuminate\Auth\Passwords\CanResetPassword;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
 use Kodeine\Acl\Traits\HasRole;
 
-class User extends Model
+class User extends Authenticatable
 {
-    use Authenticatable, CanResetPassword, HasRole, SoftDeletes;
+    use HasRole, SoftDeletes;
     
     /**
      * The attributes that are fillable via mass assignment.
      *
      * @var array
      */
-    protected $fillable = ['username', 'first_name', 'last_name', 'email', 'password',];
-
-    /**
-     * The database table used by the model.
-     *
-     * @var string
-     */
-    protected $table = 'users';
+    protected $fillable = ['name', 'email', 'password',];
 }

--- a/src/Kodeine/Acl/Traits/HasPermissionInheritance.php
+++ b/src/Kodeine/Acl/Traits/HasPermissionInheritance.php
@@ -47,11 +47,7 @@ trait HasPermissionInheritance
             // process inherit_id recursively
             $inherited = $this->getRecursiveInherit($row->inherit_id, $row->slug);
             $merge = $permissions->where('name', $row->name);
-            $merge = method_exists($merge, 'pluck') ? $merge->pluck('slug', 'name') : $merge->lists('slug', 'name');
-
-                // fix for l5.1 and backward compatibility.
-            // lists() method should return as an array.
-            $merge = $this->collectionAsArray($merge);
+            $merge = $merge->pluck('slug', 'name')->all();
 
             // replace and merge permissions
             $rights = array_replace_recursive($rights, $inherited, $merge);

--- a/src/Kodeine/Acl/Traits/HasRole.php
+++ b/src/Kodeine/Acl/Traits/HasRole.php
@@ -3,13 +3,15 @@
 namespace Kodeine\Acl\Traits;
 
 use Kodeine\Acl\Traits\HasPermission;
+use Illuminat\Support\Str;
+
 /**
  * Class HasRoleImplementation
  * @package Kodeine\Acl\Traits
  *
  * @method static Builder|Collection|\Eloquent role($role, $column = null)
  */
-trait HasRoleImplementation
+trait HasRole
 {
     use HasPermission;
 
@@ -266,13 +268,13 @@ trait HasRoleImplementation
     public function __call($method, $arguments)
     {
         // Handle isRoleSlug() methods
-        if ( starts_with($method, 'is') and $method !== 'is' and ! starts_with($method, 'isWith') ) {
+        if ( str::startsWith($method, 'is') and $method !== 'is' and ! str::startsWith($method, 'isWith') ) {
             $role = substr($method, 2);
             return $this->hasRole($role);
         }
 
         // Handle canDoSomething() methods
-        if ( starts_with($method, 'can') and $method !== 'can' and ! starts_with($method, 'canWith') ) {
+        if ( str::startsWith($method, 'can') and $method !== 'can' and ! str::startsWith($method, 'canWith') ) {
             $permission = substr($method, 3);
             $permission = snake_case($permission, '.');
 
@@ -280,20 +282,5 @@ trait HasRoleImplementation
         }
 
         return parent::__call($method, $arguments);
-    }
-}
-
-$laravel = app();
-if ($laravel instanceof \Illuminate\Foundation\Application && version_compare($laravel::VERSION, '5.3', '<')) {
-    trait HasRole
-    {
-        use HasRoleImplementation {
-            hasRole as is;
-        }
-    }
-} else {
-    trait HasRole
-    {
-        use HasRoleImplementation;
     }
 }

--- a/src/Kodeine/Acl/Traits/HasRole.php
+++ b/src/Kodeine/Acl/Traits/HasRole.php
@@ -48,10 +48,10 @@ trait HasRoleImplementation
             }
         );
 
-        $slugs = method_exists($this_roles, 'pluck') ? $this_roles->pluck('slug','id') : $this_roles->lists('slug','id');
+        $slugs = $this_roles->pluck('slug','id');
         return is_null($this_roles)
             ? []
-            : $this->collectionAsArray($slugs);
+            : $slugs->all();
     }
 
     /**

--- a/src/Kodeine/Acl/Traits/HasUserPermission.php
+++ b/src/Kodeine/Acl/Traits/HasUserPermission.php
@@ -119,7 +119,7 @@ trait HasUserPermission
      */
     protected function addSlug($alias, array $permissions)
     {
-        $slugs = method_exists($this->permissions, 'pluck') ? $this->permissions->pluck('slug', 'name') : $this->permissions->lists('slug', 'name');
+        $slugs = $this->permissions->pluck('slug', 'name');
         $collection = new Collection($slugs);
 
         if ( $collection->has($alias) ) {
@@ -140,7 +140,7 @@ trait HasUserPermission
      */
     protected function removeSlug($alias, array $permissions)
     {
-        $slugs = method_exists($this->permissions, 'pluck') ? $this->permissions->pluck('slug', 'name') : $this->permissions->lists('slug', 'name');
+        $slugs = $this->permissions->pluck('slug', 'name');
         $collection = new Collection($slugs);
 
         if ( $collection->has($alias) ) {

--- a/src/config/acl.php
+++ b/src/config/acl.php
@@ -1,6 +1,19 @@
 <?php
 
 return [
+
+    /*
+    /--------------------------------------------------------------------------
+    / Custom Database Options
+    /--------------------------------------------------------------------------
+    /
+    / If you want to add a prefix to your acl tables, or if you use a different
+    / table for your user class, define it here
+    */
+
+    'db_prefix'   => '',
+    'users_table' => '',
+
     /*
     |--------------------------------------------------------------------------
     | Model Definitions

--- a/src/migrations/2015_02_07_172633_create_role_user_table.php
+++ b/src/migrations/2015_02_07_172633_create_role_user_table.php
@@ -13,6 +13,7 @@ class CreateRoleUserTable extends Migration
     public function __construct()
     {
         $this->prefix = config('acl.db_prefix');
+        $this->users_table = config('acl.users_table') === '' ? 'users' : config('acl.users_table');
     }
 
     /**
@@ -37,7 +38,7 @@ class CreateRoleUserTable extends Migration
 
             $table->foreign('user_id')
                 ->references('id')
-                ->on(config('acl.users_table'))
+                ->on()
                 ->onDelete('cascade');
         });
     }

--- a/src/migrations/2015_02_07_172633_create_role_user_table.php
+++ b/src/migrations/2015_02_07_172633_create_role_user_table.php
@@ -26,7 +26,7 @@ class CreateRoleUserTable extends Migration
             $table->increments('id');
 
             $table->integer('role_id')->unsigned()->index()->foreign()->references("id")->on("roles")->onDelete("cascade");
-            $table->integer('user_id')->unsigned()->index()->foreign()->references("id")->on("users")->onDelete("cascade");
+            $table->bigInteger('user_id')->unsigned()->index()->foreign()->references("id")->on("users")->onDelete("cascade");
 
             $table->timestamps();
 

--- a/src/migrations/2015_02_17_152439_create_permission_user_table.php
+++ b/src/migrations/2015_02_17_152439_create_permission_user_table.php
@@ -25,7 +25,7 @@ class CreatePermissionUserTable extends Migration
 		Schema::create($this->prefix . 'permission_user', function (Blueprint $table) {
 			$table->increments('id');
 			$table->integer('permission_id')->unsigned()->index()->references('id')->on('permissions')->onDelete('cascade');
-			$table->integer('user_id')->unsigned()->index()->references('id')->on('users')->onDelete('cascade');
+			$table->bigInteger('user_id')->unsigned()->index()->references('id')->on('users')->onDelete('cascade');
 			$table->timestamps();
 		});
 	}

--- a/src/migrations/2016_02_06_172606_create_users_table_if_doesnt_exist.php
+++ b/src/migrations/2016_02_06_172606_create_users_table_if_doesnt_exist.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateUsersTable extends Migration
+class CreateUsersTableIfDoesntExist extends Migration
 {
 
     /**

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -60,7 +60,7 @@ class UserTest extends ModelsTest
         ]);
         
         $user = new User();
-        $user->username = 'Role test';
+        $user->name = 'Role test';
         $user->email = 'role@test.com';
         $user->password = 'RoleTest';
         $user->save();
@@ -97,7 +97,7 @@ class UserTest extends ModelsTest
         $role->syncPermissions($permission);
         
         $user = new User();
-        $user->username = 'Role test';
+        $user->name = 'Role test';
         $user->email = 'role@test.com';
         $user->password = 'RoleTest';
         $user->save();
@@ -134,7 +134,7 @@ class UserTest extends ModelsTest
         $role->syncPermissions($permission);
         
         $user = new User();
-        $user->username = 'Cache test';
+        $user->name = 'Cache test';
         $user->email = 'cache@test.com';
         $user->password = 'CacheTest';
         $user->save();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -119,6 +119,7 @@ abstract class TestCase extends BaseTestCase
      */
     protected function migrate()
     {
+        $this->loadLaravelMigrations();
         $this->loadMigrationsFrom($this->getMigrationsSrcPath());
     }
 


### PR DESCRIPTION
Changes:

* Removed the old collectionAsArray method that was used to get around the L5.1 List method incompatibility

* Removed other conditional code for 5.x compatibility that is no longer needed for a 6.x only package

* Updated the User model and migrations to reflect laravel 6.x versions, including adding a note to the readme about upgrading from 5.x to make sure the id column on the users table is bigInt

* Added option to configure your own users table, this was supported in that the migrations tried to grab the config value and failed because it didn't exist, killing the migrations 

* Moved deprecated starts_with method to Str::startsWith

All the tests in the repo are green and I have also tested this out in a fresh Laravel 6.0 app, which I did not do last time. 

