### PR TITLE
Fix typo in HasRole trait

### DIFF
--- a/src/Kodeine/Acl/Traits/HasRole.php
+++ b/src/Kodeine/Acl/Traits/HasRole.php
@@ -3,7 +3,7 @@
 namespace Kodeine\Acl\Traits;
 
 use Kodeine\Acl\Traits\HasPermission;
-use Illuminat\Support\Str;
+use Illuminate\Support\Str;
 
 /**
  * Class HasRoleImplementation


### PR DESCRIPTION
It always amazes me how something so simple can somehow manage to not fail any tests until it's too late. 

@kodeine sorry, don't know how this didn't trip any tests considering all of them use the HasRole trait. 