### PR TITLE
Fix cache TTL

### DIFF
--- a/src/Kodeine/Acl/Models/Eloquent/Role.php
+++ b/src/Kodeine/Acl/Models/Eloquent/Role.php
@@ -59,7 +59,7 @@ class Role extends Model
     {
         return \Cache::remember(
             'acl.getPermissionsInheritedById_'.$this->id,
-            config('acl.cacheMinutes'),
+            now()->addMinutes(config('acl.cacheMinutes', 1)),
             function () {
                 return $this->getPermissionsInherited();
             }

--- a/src/Kodeine/Acl/Traits/HasPermission.php
+++ b/src/Kodeine/Acl/Traits/HasPermission.php
@@ -42,7 +42,7 @@ trait HasPermission
         // user permissions overridden from role.
         $permissions = \Cache::remember(
             'acl.getPermissionsById_'.$this->id,
-            config('acl.cacheMinutes'),
+            now()->addMinutes(config('acl.cacheMinutes', 1)),
             function () {
                 return $this->getPermissionsInherited();
             }
@@ -83,7 +83,7 @@ trait HasPermission
         // all of user role permissions
         $merge =  \Cache::remember(
             'acl.getMergeById_'.$this->id,
-            config('acl.cacheMinutes'),
+            now()->addMinutes(config('acl.cacheMinutes', 1)),
             function () {
                 return $this->getPermissions();
             }

--- a/src/Kodeine/Acl/Traits/HasRole.php
+++ b/src/Kodeine/Acl/Traits/HasRole.php
@@ -44,7 +44,7 @@ trait HasRole
     {
         $this_roles = \Cache::remember(
             'acl.getRolesById_'.$this->id,
-            config('acl.cacheMinutes'),
+            now()->addMinutes(config('acl.cacheMinutes', 1)),
             function () {
                 return $this->roles;
             }


### PR DESCRIPTION
In Laravel 5.8, the cache was changed so it could accept seconds for TTL rather than minutes.
https://laravel.com/docs/5.8/upgrade#cache-ttl-in-seconds

It appears that this hasn't been changed in Kodeine so currently, the cache works for 1 second only by default. Changed it back to use minutes and also added a default value to the config helper in case it is does not exist.

