### PR TITLE
Prefix fix

### DIFF
--- a/src/migrations/2015_02_07_172633_create_role_user_table.php
+++ b/src/migrations/2015_02_07_172633_create_role_user_table.php
@@ -38,7 +38,7 @@ class CreateRoleUserTable extends Migration
 
             $table->foreign('user_id')
                 ->references('id')
-                ->on()
+                ->on($this->prefix . 'users')
                 ->onDelete('cascade');
         });
     }


### PR DESCRIPTION
Illuminate\Database\QueryException  : SQLSTATE[HY000]: General error: 1824 Failed to open the referenced table '1' (SQL: alter table `role_user` add constraint `role_user_user_id_foreign` foreign key (`user_id`) references `1` (`id`) on delete cascade)