### PR TITLE
Bugfix: cannot install package if the users table has a different name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "pennyappeal-charity/laravel-acl",
+    "name": "kodeine/laravel-acl",
     "description": "Light-weight role-based permissions for Laravel 5 built in Auth system.",
     "license": "MIT",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "kodeine/laravel-acl",
+    "name": "pennyappeal-charity/laravel-acl",
     "description": "Light-weight role-based permissions for Laravel 5 built in Auth system.",
     "license": "MIT",
     "keywords": [

--- a/src/Kodeine/Acl/Helper/Config.php
+++ b/src/Kodeine/Acl/Helper/Config.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Kodeine\Acl\Helper;
+
+class Config
+{
+    public static function usersTableName()
+    {
+        return config('acl.users_table') === '' ? 'users' : config('acl.users_table');
+    }
+}

--- a/src/migrations/2015_02_07_172633_create_role_user_table.php
+++ b/src/migrations/2015_02_07_172633_create_role_user_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Kodeine\Acl\Helper\Config;
 
 class CreateRoleUserTable extends Migration
 {
@@ -13,7 +14,6 @@ class CreateRoleUserTable extends Migration
     public function __construct()
     {
         $this->prefix = config('acl.db_prefix');
-        $this->users_table = config('acl.users_table') === '' ? 'users' : config('acl.users_table');
     }
 
     /**
@@ -27,7 +27,13 @@ class CreateRoleUserTable extends Migration
             $table->increments('id');
 
             $table->integer('role_id')->unsigned()->index()->foreign()->references("id")->on("roles")->onDelete("cascade");
-            $table->bigInteger('user_id')->unsigned()->index()->foreign()->references("id")->on("users")->onDelete("cascade");
+            $table->bigInteger('user_id')
+                ->unsigned()
+                ->index()
+                ->foreign()
+                ->references("id")
+                ->on(Config::usersTableName())
+                ->onDelete("cascade");
 
             $table->timestamps();
 
@@ -38,7 +44,7 @@ class CreateRoleUserTable extends Migration
 
             $table->foreign('user_id')
                 ->references('id')
-                ->on($this->prefix . 'users')
+                ->on($this->prefix . Config::usersTableName())
                 ->onDelete('cascade');
         });
     }

--- a/src/migrations/2015_02_17_152439_create_permission_user_table.php
+++ b/src/migrations/2015_02_17_152439_create_permission_user_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Kodeine\Acl\Helper\Config;
 
 class CreatePermissionUserTable extends Migration
 {
@@ -25,7 +26,12 @@ class CreatePermissionUserTable extends Migration
 		Schema::create($this->prefix . 'permission_user', function (Blueprint $table) {
 			$table->increments('id');
 			$table->integer('permission_id')->unsigned()->index()->references('id')->on('permissions')->onDelete('cascade');
-			$table->bigInteger('user_id')->unsigned()->index()->references('id')->on('users')->onDelete('cascade');
+			$table->bigInteger('user_id')
+                ->unsigned()
+                ->index()
+                ->references('id')
+                ->on(Config::usersTableName())
+                ->onDelete('cascade');
 			$table->timestamps();
 		});
 	}

--- a/src/migrations/2016_02_06_172606_create_users_table_if_doesnt_exist.php
+++ b/src/migrations/2016_02_06_172606_create_users_table_if_doesnt_exist.php
@@ -2,10 +2,10 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Kodeine\Acl\Helper\Config;
 
 class CreateUsersTableIfDoesntExist extends Migration
 {
-
     /**
      * Run the migrations.
      *
@@ -13,8 +13,8 @@ class CreateUsersTableIfDoesntExist extends Migration
      */
     public function up()
     {
-        if (!Schema::hasTable('users')) {
-            Schema::create('users', function (Blueprint $table) {
+        if (!Schema::hasTable(Config::usersTableName())) {
+            Schema::create(Config::usersTableName(), function (Blueprint $table) {
                 $table->increments('id');
                 $table->string('username');
                 $table->string('first_name', 30)->nullable();
@@ -34,6 +34,8 @@ class CreateUsersTableIfDoesntExist extends Migration
      */
     public function down()
     {
-        Schema::drop('users');
+        // @todo Are you sure? What if there was already a users table and the up() method above did nothing?
+        // Would it not be safer to leave a dangling unused table than to drop a potentially vital table?
+        // Schema::drop('users');
     }
 }


### PR DESCRIPTION
The laravel-acl migrations have the 'users' table name hardwired in them and this pull request replaces the hard-wired names with the configured name at acl.users_table.
It also does not drop the users table in the down() method of the migration that creates the users table if it doesn't already exist as I believe this should not be done, see the comment added inside that method.