### PR TITLE
PublishMigrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ composer require kodeine/laravel-acl "^1.0"
 ],
 ```
 
-3. Publish the package configuartion files and add your own models to the list of ACL models"
+3. Publish the package configuartion files, migrations and add your own models to the list of ACL models"
 
 ```
 $ php artisan vendor:publish --provider="Kodeine\Acl\AclServiceProvider"

--- a/src/Kodeine/Acl/AclServiceProvider.php
+++ b/src/Kodeine/Acl/AclServiceProvider.php
@@ -21,8 +21,20 @@ class AclServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->publishConfig();
-        $this->loadMigrationsFrom(__DIR__ . '/../../migrations');
+        $this->publishes(
+            [
+                __DIR__ . '/../../config/acl.php' => config_path('acl.php')
+            ],
+            'config'
+        );
+
+        $this->publishes(
+            [
+                __DIR__ . '/../../migrations/' => base_path('/database/migrations')
+            ],
+            'migrations'
+        );
+
         $this->registerBladeDirectives();
     }
 
@@ -36,16 +48,6 @@ class AclServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(
             __DIR__ . '/../../config/acl.php', 'acl'
         );
-    }
-
-    /**
-     * Publish the config file to the application config directory
-     */
-    public function publishConfig()
-    {
-        $this->publishes([
-            __DIR__ . '/../../config/acl.php' => config_path('acl.php'),
-        ], 'config');
     }
 
     public function registerBladeDirectives()


### PR DESCRIPTION
Sometimes standard migrations need to be tweaked a bit. For example, when the user's id is not numeric, but uuid, ulid. Then a different ID format is used. It is good to have all migrations in one database/migrations folder.