### PR TITLE
Add support for Laravel 8

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/tests             export-ignore
+.gitattributes     export-ignore
+.gitignore         export-ignore
+.travis.yml        export-ignore
+phpunit.xml.dist   export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4
+  - 8.0snapshot
 
 before_script:
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction --prefer-source
 
 script:
-  - vendor/bin/phpunit --debug tests/
+  - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     ],
     "require": {
         "php": ">=7.2",
-        "illuminate/support": "^6.0|^7.0"
+        "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
-        "orchestra/testbench": "^4.0|^5.0",
+        "phpunit/phpunit": "^8.0|^9.0",
+        "orchestra/testbench": "^5.0|^6.0",
         "doctrine/dbal": "^2.9"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         verbose="true"
+>
+    <testsuites>
+        <testsuite name="Laravel-ACL Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
This pull request adds support for Laravel 8 and adds php 7.4 and 8.0 to the Travis CI build. [The Travis CI builds are all green.](https://travis-ci.com/github/chris-doehring/laravel-acl/builds/203992154).

The .travis.yml and composer.json appears to be completly changed in the diff, since I changed their line endings from CRLF to LF.