### PR TITLE
Removing the non necessary code to fix constraint incompatibility  error on …

### DIFF
--- a/src/migrations/2015_11_30_232041_bigint_user_keys.php
+++ b/src/migrations/2015_11_30_232041_bigint_user_keys.php
@@ -24,8 +24,8 @@ class BigintUserKeys extends Migration
      */
     public function down()
     {
-        Schema::table('role_user', function (Blueprint $table) {
-            $table->integer("user_id")->unsigned()->change();
-        });
+        // Schema::table('role_user', function (Blueprint $table) {
+        //     $table->integer("user_id")->unsigned()->change();
+        // });
     }
 }


### PR DESCRIPTION
When running ```php artisan migrate:refresh```, it caused the following error:

```
Illuminate\Database\QueryException 

  SQLSTATE[HY000]: General error: 3780 Referencing column 'user_id' and referenced column 'id' in foreign key constraint 'role_user_user_id_foreign' are incompatible. (SQL: ALTER TABLE role_user CHANGE user_id user_id INT UNSIGNED NOT NULL)
...
```

The solution is to remove the down part of this migration.