### PR TITLE
Added:  Different guard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ composer require kodeine/laravel-acl "^1.0"
 $ php artisan vendor:publish --provider="Kodeine\Acl\AclServiceProvider"
 ```
 
-> **Use your own models.**
-> Once you publish, it publishes the configuration file where you can define your own models which should extend to Acl models.
+> **Once you publish, it publishes the configuration file where you can:**
+> - **Use your own models**: Define your own models which should extend to Acl models.
+> - **Use your own guard**: Define a guard other than laravel default for user recovery.
 
 4. Add the middleware to your `app/Http/Kernel.php`.
 
@@ -99,6 +100,9 @@ Here's the TODO list for the next release.
 * [ ] Adding cache to final user permissions.
 
 # <a name="change-logs"></a>Change Logs
+
+**June 14 2022**
+* [x] Added support for different guard
 
 **September 14 2019**
 * [x] Updated the readme to reflect new major release

--- a/src/Kodeine/Acl/AclServiceProvider.php
+++ b/src/Kodeine/Acl/AclServiceProvider.php
@@ -50,14 +50,21 @@ class AclServiceProvider extends ServiceProvider
 
     public function registerBladeDirectives()
     {
-        // role
-        Blade::if('role', function ($expression) {
-            return Auth::guard(config('acl.guard'))->check() && Auth::guard(config('acl.guard'))->user()->hasRole($expression);
+        Blade::directive('role', function ($expression) {
+            return "<?php if (Auth::guard(config('acl.guard'))->check() && Auth::guard(config('acl.guard'))->user()->hasRole({$expression})): ?>";
+        });
+
+        Blade::directive('endrole', function () {
+            return "<?php endif; ?>";
         });
 
         // permission
-        Blade::if('permission', function ($expression) {
-            return Auth::guard(config('acl.guard'))->check() && Auth::guard(config('acl.guard'))->user()->hasPermission($expression);
+        Blade::directive('permission', function ($expression) {
+            return "<?php if (Auth::guard(config('acl.guard'))->check() && Auth::guard(config('acl.guard'))->user()->hasPermission({$expression})): ?>";
+        });
+
+        Blade::directive('endpermission', function () {
+            return "<?php endif; ?>";
         });
     }
 }

--- a/src/Kodeine/Acl/AclServiceProvider.php
+++ b/src/Kodeine/Acl/AclServiceProvider.php
@@ -51,21 +51,13 @@ class AclServiceProvider extends ServiceProvider
     public function registerBladeDirectives()
     {
         // role
-        Blade::directive('role', function ($expression) {
-            return "<?php if (Auth::check() && Auth::user()->hasRole({$expression})): ?>";
-        });
-
-        Blade::directive('endrole', function () {
-            return "<?php endif; ?>";
+        Blade::if('role', function ($expression) {
+            return Auth::guard(config('acl.guard'))->check() && Auth::guard(config('acl.guard'))->user()->hasRole($expression);
         });
 
         // permission
-        Blade::directive('permission', function ($expression) {
-            return "<?php if (Auth::check() && Auth::user()->hasPermission({$expression})): ?>";
-        });
-
-        Blade::directive('endpermission', function () {
-            return "<?php endif; ?>";
+        Blade::if('permission', function ($expression) {
+            return Auth::guard(config('acl.guard'))->check() && Auth::guard(config('acl.guard'))->user()->hasPermission($expression);
         });
     }
 }

--- a/src/Kodeine/Acl/Middleware/HasPermission.php
+++ b/src/Kodeine/Acl/Middleware/HasPermission.php
@@ -39,6 +39,7 @@ class HasPermission
     public function handle($request, Closure $next)
     {
         $this->request = $request;
+        $this->guard = config('acl.guard');
 
         // override crud resources via config
         $this->crudConfigOverride();
@@ -73,8 +74,9 @@ class HasPermission
     {
         $request = $this->request;
         $role = $this->getAction('is');
+        $guard = $this->guard;
 
-        return ! $this->forbiddenRoute() && $request->user()->hasRole($role);
+        return ! $this->forbiddenRoute() && $request->user($guard)->hasRole($role);
     }
 
     /**
@@ -86,8 +88,9 @@ class HasPermission
     {
         $request = $this->request;
         $do = $this->getAction('can');
+        $guard = $this->guard;
 
-        return ! $this->forbiddenRoute() && $request->user()->hasPermission($do);
+        return ! $this->forbiddenRoute() && $request->user($guard)->hasPermission($do);
     }
 
     /**
@@ -104,6 +107,9 @@ class HasPermission
 
         // protection methods being passed in a route.
         $methods = $this->getAction('protect_methods');
+
+        // guard from config 
+        $guard = $this->guard;
 
         // get method being called on controller.
         $caller = $this->parseMethod();
@@ -133,7 +139,7 @@ class HasPermission
             return $e . '.' . $this->parseAlias();
         }, array_keys($crud)));
 
-        return ! $this->forbiddenRoute() && $request->user()->hasPermission($permission);
+        return ! $this->forbiddenRoute() && $request->user($guard)->hasPermission($permission);
     }
     
     private function filterMethods($methods, $callback) {

--- a/src/config/acl.php
+++ b/src/config/acl.php
@@ -44,4 +44,11 @@ return [
      */
 		
     'cacheMinutes' => 1,
+
+    /**
+     * Guard
+     * Set the guard for user validations.
+     */
+
+    'guard' => config('auth.defaults.guard'),
 ];


### PR DESCRIPTION
**This fixes handling of a different guard other than application default.**

Fixes: #135.

- Guard parameter on config file to get default;

```php
  /**
   * Guard
   * Set the guard for user validations.
   */
  'guard' => config('auth.defaults.guard'),
```

- Added guard on  HasPermission handle;
```php
   $this->guard = config('acl.guard');
```

- Added `$guard = $this->guard`  on hasRole, hasPermission and protectMethods;

- Changed `$request->user()`  to `$request->user($guard)` on hasRole, hasPermission and protectMethods;


- Changed Blade directives to `Blade::if` method and guard added;
```php
   // role
   Blade::if('role', function ($expression) {
        return Auth::guard(config('acl.guard'))->check() && Auth::guard(config('acl.guard'))->user()->hasRole($expression);
   });

   // permission
   Blade::if('permission', function ($expression) {
        return Auth::guard(config('acl.guard'))->check() && Auth::guard(config('acl.guard'))->user()->hasPermission($expression);
   });
```